### PR TITLE
Refactor library/UI

### DIFF
--- a/Kindelabra.py
+++ b/Kindelabra.py
@@ -360,13 +360,7 @@ class KindleUI:
         self.status("Kindle collections reloaded")
 
     def save(self, widget):
-        now = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
-        backup = os.path.join(self.root, 'system', '%s-collections.json.backup' % (now))
-        jsonfile = os.path.join(self.root, 'system', 'collections.json')
-        if os.path.exists(jsonfile):
-            os.rename(jsonfile, backup)
-        with open(os.path.join(self.root, 'system', 'collections.json'), 'wb') as colfile:
-            json.dump(self.db.toKindleDb(), colfile, separators=(',', ':'), ensure_ascii=True)
+        self.kindle.saveDb(self.db)
         self.status("Collections saved to Kindle, restart to load your new collections")
 
     def get_filenodes(self, tree, nodes):

--- a/Kindelabra.py
+++ b/Kindelabra.py
@@ -156,7 +156,7 @@ class KindleUI:
             treesel.select_iter(coliter)
             treepath = treesel.get_selected_rows()[1][0]
             self.colview.scroll_to_cell(treepath)
-            self.db[colname] = kindle.Collection({ 'locale': 'en-US', 'items': [], 'lastAccess': 0})
+            self.db[colname] = kindle.Collection()
         else:
             self.status("%s collection already exists" % colname)
 

--- a/Kindelabra.py
+++ b/Kindelabra.py
@@ -302,7 +302,7 @@ class KindleUI:
                         asin = self.kindle.files[filehash].asin
                         if not self.db.in_collection(colname, asin):
                             colstore.append(colstore[colpath].iter, [filename, filehash, asin])
-                            self.db.add_asin(colname, self.kindle.files[filehash].asin, self.kindle.files[filehash].type)
+                            self.db.add_ebook(colname, self.kindle.files[filehash])
                     except TypeError:
                         if not self.db.in_collection(colname, filehash):
                             colstore.append(colstore[colpath].iter, [filename, filehash, ""])

--- a/Kindelabra.py
+++ b/Kindelabra.py
@@ -298,15 +298,13 @@ class KindleUI:
             for colpath, colname in targetcols:
                 colname = unicode(colname)
                 if colname in self.db:
-                    try:
-                        asin = self.kindle.files[filehash].asin
-                        if not self.db.in_collection(colname, asin):
-                            colstore.append(colstore[colpath].iter, [filename, filehash, asin])
-                            self.db.add_ebook(colname, self.kindle.files[filehash])
-                    except TypeError:
-                        if not self.db.in_collection(colname, filehash):
-                            colstore.append(colstore[colpath].iter, [filename, filehash, ""])
-                            self.db.add_filehash(colname, filehash)
+					f = self.kindle.files[filehash]
+					if not self.db.in_collection(colname, f):
+						asin = f.asin
+						if asin == None:
+							asin = ""
+						colstore.append(colstore[colpath].iter, [filename, filehash, asin])
+						self.db.add_ebook(colname, f)
                 else:
                     self.status("No such collection:" + colname)
         #self.colview.expand_all()

--- a/Kindelabra.py
+++ b/Kindelabra.py
@@ -327,11 +327,11 @@ class KindleUI:
                 book = self.kindle.searchAsin(asin)
                 asin = "#%s^%s" % (book.asin, book.type)
                 if self.db[collection].has_hash(asin):
-                    self.db[collection]['items'].remove(asin)
+                    self.db[collection].remove_hash(asin)
                     colstore.remove(colstore[path].iter)
             elif self.db[collection].has_hash(filehash):
                 jsonhash = '*' + filehash
-                self.db[collection]['items'].remove(jsonhash)
+                self.db[collection].remove_hash(jsonhash)
                 colstore.remove(colstore[path].iter)
             else:
                 self.status("File not in collection")

--- a/kindle.py
+++ b/kindle.py
@@ -91,11 +91,14 @@ class Ebook():
         self.meta = None
         self.asin = None
         self.type = None
+        self.author = None
         ext = os.path.splitext(path)[1][1:].lower()
         if ext in ['mobi', 'azw']:
             self.meta = ebook.Mobi(path)
             if self.meta.title:
                 self.title = self.meta.title
+                if 100 in self.meta.exth:
+                    self.author = self.meta.exth[100]
                 if 113 in self.meta.exth:
                     self.asin = self.meta.exth[113]
                 if 501 in self.meta.exth:

--- a/kindle.py
+++ b/kindle.py
@@ -67,6 +67,9 @@ class CollectionDB(dict):
     def add_asin(self, collection, asin, booktype):
         asin = "#%s^%s" % (asin, booktype)
         self[collection]['items'].append(asin)
+    
+    def add_ebook(self, collection, ebook):
+        self.add_asin(collection, ebook.asin, ebook.type)
 
 class Ebook():
     def __init__(self, path):

--- a/kindle.py
+++ b/kindle.py
@@ -12,6 +12,7 @@ import re
 import json
 import sys
 import datetime
+import codecs
 
 import ebook
 
@@ -71,6 +72,8 @@ class CollectionDB(dict):
     def add_ebook(self, collection, ebook):
         self[collection].add_hash(ebook.fileident())
 
+utf8 = codecs.getdecoder("utf-8")
+
 class Ebook():
     def __init__(self, path):
         self.path = get_kindle_path(path)
@@ -86,13 +89,13 @@ class Ebook():
             if self.meta.title:
                 self.title = self.meta.title
                 if 100 in self.meta.exth:
-                    self.author = self.meta.exth[100]
+                    self.author = utf8(self.meta.exth[100])[0]
                 if 113 in self.meta.exth:
                     self.asin = self.meta.exth[113]
                 if 501 in self.meta.exth:
                     self.type = self.meta.exth[501]
                 if 503 in self.meta.exth:
-                    self.title = self.meta.exth[503]
+                    self.title = utf8(self.meta.exth[503])[0]
             else:
                 print "\nMetadata read error:", path
         elif ext in ['tpz', 'azw1']:

--- a/kindle.py
+++ b/kindle.py
@@ -36,6 +36,9 @@ class Collection(dict):
     def remove_hash(self, filehash):
         self['items'].remove(filehash)
 
+    def count(self):
+        return len(self['items'])
+
 class CollectionDB(dict):
     '''Holds a collection database
     '''

--- a/kindle.py
+++ b/kindle.py
@@ -19,6 +19,9 @@ FILTER = ['pdf', 'mobi', 'prc', 'txt', 'tpz', 'azw1', 'azw', 'manga', 'azw2']
 FOLDERS = ['documents', 'pictures']
 
 class Collection(dict):
+    def __init__(self, arg = { 'locale': 'en-US', 'items': [], 'lastAccess': 0}):
+        super(Collection, self).__init__(arg)
+
     '''Holds a single collection
     '''
     def has_hash(self, filehash):

--- a/kindle.py
+++ b/kindle.py
@@ -11,6 +11,7 @@ import os
 import re
 import json
 import sys
+import datetime
 
 import ebook
 
@@ -174,6 +175,19 @@ class Kindle:
         docs = os.path.exists(os.path.join(self.root, 'documents'))
         sys = os.path.exists(os.path.join(self.root, 'system'))
         return docs and sys
+
+    def getDb(self):
+        colfile = os.path.join(self.root, 'system', 'collections.json')
+        return CollectionDB(colfile)
+    
+    def saveDb(self, db):
+        now = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+        backup = os.path.join(self.root, 'system', '%s-collections.json.backup' % (now))
+        jsonfile = os.path.join(self.root, 'system', 'collections.json')
+        if os.path.exists(jsonfile):
+            os.rename(jsonfile, backup)
+        with open(os.path.join(self.root, 'system', 'collections.json'), 'wb') as colfile:
+            json.dump(db.toKindleDb(), colfile, separators=(',', ':'), ensure_ascii=True)
 
 # Returns a full path on the kindle filesystem
 def get_kindle_path(path):

--- a/kindle.py
+++ b/kindle.py
@@ -146,6 +146,7 @@ class Kindle:
                     book = Ebook(fullpath)
                     self.files[book.hash] = book
                     sys.stdout.write(".")
+                    sys.stdout.flush()
         sys.stdout.write("\n")
 
     def searchAsin(self, asin):

--- a/kindle.py
+++ b/kindle.py
@@ -28,10 +28,7 @@ class Collection(dict):
     '''Holds a single collection
     '''
     def has_hash(self, filehash):
-        for item in self['items']:
-            if not item.find(filehash) == -1:
-                return True
-        return False
+        return filehash in self['items']
 
     def add_hash(self, filehash):
         self['items'].append(filehash)
@@ -65,25 +62,11 @@ class CollectionDB(dict):
             tmpjson[tmpkey] = tmpvalue
         return tmpjson
 
-    def in_collection(self, collection, filehash):
-        if self[collection].has_hash(filehash):
-            return True
-        else:
-            return False
+    def in_collection(self, collection, ebook):
+        return self[collection].has_hash(ebook.fileident())
 
-    def add_filehash(self, collection, filehash):
-        filehash = '*'+filehash
-        self[collection].add_hash(filehash)
-
-    def add_asin(self, collection, asin, booktype):
-        asin = "#%s^%s" % (asin, booktype)
-        self[collection].add_hash(asin)
-    
     def add_ebook(self, collection, ebook):
-        if ebook.asin != None:
-            self.add_asin(collection, ebook.asin, ebook.type)
-        else:
-            self.add_filehash(collection, ebook.hash)
+        self[collection].add_hash(ebook.fileident())
 
 class Ebook():
     def __init__(self, path):
@@ -129,6 +112,12 @@ class Ebook():
             else:
                 # Couldn't get an ASIN, developper app? We'll use the hash instead, which is what the Kindle itself does, so no harm done.
                 print "\nKindlet Metadata read error, assuming developper app:", path
+    
+    def fileident(self):
+        if self.asin == None:
+            return '*'+self.hash
+        else:
+            return "#%s^%s" % (self.asin, self.type)
 
 class Kindle:
     '''Access a Kindle filesystem

--- a/kindle.py
+++ b/kindle.py
@@ -20,7 +20,9 @@ FILTER = ['pdf', 'mobi', 'prc', 'txt', 'tpz', 'azw1', 'azw', 'manga', 'azw2']
 FOLDERS = ['documents', 'pictures']
 
 class Collection(dict):
-    def __init__(self, arg = { 'locale': 'en-US', 'items': [], 'lastAccess': 0}):
+    def __init__(self, arg = None):
+        if arg == None:
+            arg = { 'locale': 'en-US', 'items': [], 'lastAccess': 0}
         super(Collection, self).__init__(arg)
 
     '''Holds a single collection

--- a/kindle.py
+++ b/kindle.py
@@ -42,7 +42,9 @@ class Collection(dict):
 class CollectionDB(dict):
     '''Holds a collection database
     '''
-    def __init__(self, colfile):
+    def __init__(self, colfile = None):
+        if colfile == None:
+            return
         with open(colfile) as colfile:
             tmpjson = json.load(colfile)
             tmpdict = dict()

--- a/kindle.py
+++ b/kindle.py
@@ -30,6 +30,12 @@ class Collection(dict):
                 return True
         return False
 
+    def add_hash(self, filehash):
+        self['items'].append(filehash)
+
+    def remove_hash(self, filehash):
+        self['items'].remove(filehash)
+
 class CollectionDB(dict):
     '''Holds a collection database
     '''
@@ -62,11 +68,11 @@ class CollectionDB(dict):
 
     def add_filehash(self, collection, filehash):
         filehash = '*'+filehash
-        self[collection]['items'].append(filehash)
+        self[collection].add_hash(filehash)
 
     def add_asin(self, collection, asin, booktype):
         asin = "#%s^%s" % (asin, booktype)
-        self[collection]['items'].append(asin)
+        self[collection].add_hash(asin)
     
     def add_ebook(self, collection, ebook):
         self.add_asin(collection, ebook.asin, ebook.type)

--- a/kindle.py
+++ b/kindle.py
@@ -78,7 +78,10 @@ class CollectionDB(dict):
         self[collection].add_hash(asin)
     
     def add_ebook(self, collection, ebook):
-        self.add_asin(collection, ebook.asin, ebook.type)
+        if ebook.asin != None:
+            self.add_asin(collection, ebook.asin, ebook.type)
+        else:
+            self.add_filehash(collection, ebook.hash)
 
 class Ebook():
     def __init__(self, path):


### PR DESCRIPTION
Thanks for writing Kindelabra. I tried using the kindle.py as a standalone library for doing things, and found out that a fair chunk of the logic was tied up in the Kindelabra frontend. 

This patchset primarily pulls out those bits of functionality into the backend objects, and adds a few small bits of useful helpers into the backend to help with using it as standalone objects:
- Collection now has reasonable default values
- Rewrite add_asin/add_filehash as a unified add_ebook
- Move collection saving/loading collection into the Kindle object
- Allow for creating CollectionDB's without having to load an existing collection.
- Add initial "author" support to Ebook (only there for azw/mobi as I don't have any other items)
- Make document loading dump out the status as it loads as opposed to right at the end.
# TODO
- del_file in Kindelabra could do with rewriting (as could possibly some of the other code) to not really need to know about ASINs v.s. filehashes for storage
