### PR TITLE
Add zip to the list of supported extensions

### DIFF
--- a/kindle.py
+++ b/kindle.py
@@ -15,7 +15,7 @@ import sys
 import ebook
 
 KINDLEROOT = '/mnt/us'
-FILTER = ['pdf', 'mobi', 'prc', 'txt', 'tpz', 'azw1', 'azw', 'manga', 'azw2']
+FILTER = ['pdf', 'mobi', 'prc', 'txt', 'tpz', 'azw1', 'azw', 'manga', 'azw2', 'zip']
 FOLDERS = ['documents', 'pictures']
 
 class Collection(dict):


### PR DESCRIPTION
Kindles can read zip files containing images, but the GUI won't show them so you can't add them to any collection. This fixes the issue
